### PR TITLE
Feat/blog article link color

### DIFF
--- a/src/domain/blog/blog_article/BlogArticle.component.jsx
+++ b/src/domain/blog/blog_article/BlogArticle.component.jsx
@@ -63,6 +63,7 @@ const Blog = ({ blog, sections }) => {
                                         className={classes.textSectionContent}
                                         source={section.content} 
                                         escapeHtml={false}
+                                        linkTarget='_blank'
                                     />
                                 </div>
                             )

--- a/src/domain/blog/blog_article/BlogArticle.module.scss
+++ b/src/domain/blog/blog_article/BlogArticle.module.scss
@@ -204,6 +204,9 @@
                 .textSectionContent {
                     font-weight: $regular;
                     line-height: 34px;
+                    a {
+                        color: $brand;
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description

Changes color of links in Blog articles to orange (the brand color)
Also, made the links open in new tab, since they would be external links. If this is not required, I can revert it :)

Fixes https://trello.com/c/UxDQW95Q/261-link-colour-on-blog

# Checklist:

- [:fire:] I have commented my code, particularly in hard-to-understand areas
- [:fire:] I have reviewed the 'files changed' tab on github to ensure all changes are expected
- [:fire:] I have added someone to review the pr
